### PR TITLE
changed hardcoded libml version to not be hardcoded 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask
 flasgger
 joblib
 requests
-git+https://github.com/remla25-team17/lib-ml.git@v0.0.3
+git+https://github.com/remla25-team17/lib-ml.git

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,6 @@
 from flask import Flask, request, jsonify
 from flasgger import Swagger, swag_from
-from lib_ml.preprocessing import preprocessing
-import joblib
+from lib_ml.preprocessing import preprocess_reviews
 import requests
 import os
 


### PR DESCRIPTION

## Overview

changed the hardcoded version in requirements.txt of the lib-ml library to the non hardcoded version such that the latest version is used instead. 

changed the wrong import of the preprocessing function from the lib-ml library

## 📋 Pull Request Checklist

Please review and check all the following:

- [x] I have added an overview of the changes
- [x] I have tested my changes locally
- [x] I have updated documentation (if applicable)

---

## 🚀 Versioning (Required for GitVersion)

- [x] The **PR includes a commit** with one of the following GitVersion tags in the **message**:
  - `#major` – breaking change
  - `#minor` – new feature
  - `#patch` – bug fix or minor update  
  - _If omitted, the version will default to_ `patch`
